### PR TITLE
Add chat command and custom repo creation example for hosts

### DIFF
--- a/addons/grabber/lua/autorun/client/grabber_v0.lua
+++ b/addons/grabber/lua/autorun/client/grabber_v0.lua
@@ -363,6 +363,16 @@ hook.Add("InitPostEntity", "Grabber_InitPostEntity_LoadRepositories", function()
     grabber.LoadRepositoriesFromDisk()
 end)
 
+-- Hook into clientside chat, if the text is !grabber we want to hide it from everyone's chatbox, and then if ply is LocalPlayer(), open the GUI.
+hook.Add("OnPlayerChat", "Grabber_OnPlayerChat_OpenGrabberMenu", function(ply, text, teamChat, isDead)
+    if string.lower(text) == "!grabber" then
+        if ply == LocalPlayer() then
+            grabber.ShowGUI()
+        end
+        return true -- suppress !grabber commands for everyone
+    end
+end)
+
 
 -- =============================
 -- Grabber API

--- a/example_custom_repo.lua
+++ b/example_custom_repo.lua
@@ -1,0 +1,10 @@
+-- Server hosts can place a file like this somewhere in lua/autorun/client/
+-- to add custom repositories to Grabber for their users.
+-- MAKE SURE THAT you call grabber.AddRepository in the frame AFTER
+-- InitPostEntity runs (e.g. put it in a timer.Simple(0) callback:
+
+hook.Add("InitPostEntity", "ExampleIPE", function()
+    timer.Simple(0, function()
+        grabber.AddRepository("grabberlua", "tjb2640", "grabber-gmod", "main", "expression2")
+    end)
+end)


### PR DESCRIPTION
Adds a hook for "OnPlayerChat" to check for the `!grabber` command, and adds an example Lua file for server hosts showing them how to add custom repositories for their users.